### PR TITLE
Fixed editor name style in references

### DIFF
--- a/Template-Thesis/chapter_01.tex
+++ b/Template-Thesis/chapter_01.tex
@@ -15,7 +15,7 @@ Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod 
 
 Third and fourth level titles must be bold and only the first letter of the word the title begins with must be capital (i.e. \textbf{2.1.1 Process analysis using a histogram} or \textbf{3.1.1.2 Process analysis steps}).
 
-Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gub rgren, no sea takimata sanctus est Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut lab ore sit et dolore magna. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt.
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gub rgren, no sea takimata sanctus est Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut lab ore sit et dolore magna. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt \cite{chester2002materials}.
 
 \subsection{Third level title}
 

--- a/Template-Thesis/thesis_bib.bib
+++ b/Template-Thesis/thesis_bib.bib
@@ -243,4 +243,17 @@ issn = "0022-3514",
 author = "Miron Zuckerman and Suzanne C. Kieffer"
 }
 
+@incollection{chester2002materials,
+    author = {Chester, R.},
+    year = {2002},
+    title = {Materials Selection and Engineering},
+    booktitle = {Advances in the Bonded Composite Repair of Metallic Aircraft Structure},
+    editor = {Baker, A. A. and Rose, L. R. F. and Jones, R.},
+    edition = {2},
+    volume = {1},
+    pages = {19--40},
+    publisher = {Wiley},
+    address = {New York}
+}
+
 @Comment{jabref-meta: databaseType:biblatex;}

--- a/Template-Thesis/thesis_itu.cls
+++ b/Template-Thesis/thesis_itu.cls
@@ -387,8 +387,8 @@
 \if@Ingilizce
   \def\baglac{and}
   \def\etal{et~al.}
-  \def\duzenciler{editors}
-  \def\duzenci{editor}
+  \def\duzenciler{(Eds.)}
+  \def\duzenci{(Ed.)}
   \def\duzenleyen{edited by}
   \def\surum{edition}
   \def\cilt{volume}

--- a/Template-Thesis/thesis_itubib.bst
+++ b/Template-Thesis/thesis_itubib.bst
@@ -268,6 +268,9 @@ FUNCTION {space.word}
 FUNCTION {bbl.and}
 { "{\textbf{\baglac}}"}
 
+FUNCTION {bbl.ed.and}
+{ "{\baglac}"}
+
 FUNCTION {bbl.ve}
 { "{\textbf{ve}}"}
 
@@ -516,7 +519,6 @@ FUNCTION {format.names.ed}
     { s nameptr
       "{f{.}.~}{vv~}{ll}{ jj}"
       format.name$
-    bib.name.font
       bibinfo bibinfo.check
       't :=
       nameptr #1 >
@@ -534,7 +536,7 @@ FUNCTION {format.names.ed}
                   " " * bbl.etal emphasize *
                 }
                 {
-                  bbl.and
+                  bbl.ed.and
                   space.word * t *
                 }
               if$
@@ -815,9 +817,9 @@ FUNCTION {format.booktitle}
 FUNCTION {format.in.ed.booktitle}
 { format.booktitle duplicate$ empty$ 'skip$
     {
+      emphasize
       editor "editor" format.names.ed duplicate$ empty$ 'pop$
         {
-          "," *
           " " *
           get.bbl.editor
           ", " *


### PR DESCRIPTION
For references with book chapters, editor names were styled bold which is not correct according to the template thesis. The bold style is removed and 'editors' word is replaced with '(Eds.)'.